### PR TITLE
fix(modal): Update the showing variable when the modal closes outside the control of the Modal class 

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -9,7 +9,13 @@ export class Modal {
     this.element = element;
   }
   attached(){
-    $(this.modal).modal({show: false});
+    $(this.modal).modal({show: false})
+    .on('show.bs.modal', () => {	
+      this.showing = true;
+    })
+    .on('hide.bs.modal', () => {	
+      this.showing = false;
+    });
   }
   showingChanged(newValue){
     if (newValue) {


### PR DESCRIPTION
I am not sure how you prefer pull-requests, but I made the changes for myself and thought you might want to merge it into your project.

This might be kind of breaking in that for this to work you need to use showing.two-way instead of showing.bind on the <modal> element.

I have also made a couple of changes on my own master branch... I added dev-dependencies so that I could just do npm install followed by jspm install then gulp build which was not possible before. I also added bootstrap as a dependency and import it in modal.js since that extends jquery with the bootstrap js. Before that change you had to import the bootstrap javascript separately before you called the modal class. Are you interested in those changes as well?
