### PR TITLE
fix(build): Add dev-dependencies so that it easier to build the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,25 @@
       "jquery": "github:components/jquery@^2.1.3"
     },
     "devDependencies": {
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4",
       "traceur": "github:jmcriffey/bower-traceur@0.0.87",
       "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.87"
     }
   },
   "devDependencies": {
-    "gulp-babel": "^5.1.0"
+    "aurelia-tools": "^0.1.14",
+    "conventional-changelog": "^0.5.0",
+    "del": "^2.0.2",
+    "gulp": "^3.9.0",
+    "gulp-babel": "^5.1.0",
+    "gulp-bump": "^1.0.0",
+    "gulp-jshint": "^1.11.2",
+    "jshint-stylish": "^2.0.1",
+    "karma": "^0.13.10",
+    "require-dir": "^0.3.0",
+    "run-sequence": "^1.1.4",
+    "vinyl-paths": "^2.0.0",
+    "yargs": "^3.26.0"
   }
 }


### PR DESCRIPTION
I just added the dependencies to build the project to the gulpfile.js so that we can compile the project by doing `npm install && jspm install && gulp build`
