### PR TITLE
fix(modal): Fixed issue #18 by importing bootstrap instead of jquery as $ in modal.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,25 +1,32 @@
 System.config({
-  "paths": {
-    "*": "*.js",
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
-  }
-});
+  defaultJSExtensions: true,
+  transpiler: "babel",
+  babelOptions: {
+    "optional": [
+      "runtime",
+      "optimisation.modules.system"
+    ]
+  },
+  paths: {
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
+  },
 
-System.config({
-  "map": {
+  map: {
     "babel": "npm:babel-core@5.2.16",
     "babel-runtime": "npm:babel-runtime@5.1.11",
+    "bootstrap": "github:twbs/bootstrap@3.3.5",
     "core-js": "npm:core-js@0.8.4",
-    "jquery": "github:components/jquery@2.1.3",
     "traceur": "github:jmcriffey/bower-traceur@0.0.87",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.87",
     "github:jspm/nodelibs-process@0.1.1": {
       "process": "npm:process@0.10.1"
+    },
+    "github:twbs/bootstrap@3.3.5": {
+      "jquery": "github:components/jquery@2.1.4"
     },
     "npm:core-js@0.8.4": {
       "process": "github:jspm/nodelibs-process@0.1.1"
     }
   }
 });
-

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     },
     "dependencies": {
       "babel": "npm:babel-core@^5.2.16",
-      "jquery": "github:components/jquery@^2.1.3"
+      "bootstrap": "github:twbs/bootstrap@^3.3.5"
     },
     "devDependencies": {
+      "babel-runtime": "npm:babel-runtime@^5.8.24",
+      "core-js": "npm:core-js@^1.1.4",
       "traceur": "github:jmcriffey/bower-traceur@0.0.87",
       "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.87"
     }

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,5 +1,5 @@
 import {inject, customElement, bindable} from 'aurelia-framework';
-import $ from 'jquery';
+import $ from 'bootstrap';
 
 @customElement('modal')
 @inject(Element)


### PR DESCRIPTION
This pull request will fix #18 so that it is no longer necessary for the user to import bootstrap before using the library which I feel is a cleaner solution
