### PR TITLE
Adds support for large and small modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This plugin is for the [Aurelia](http://www.aurelia.io/) platform. It sets up a 
 4. Anywhere in your app add the following markup as a sample -
 
   ```html
-  <modal showing.bind="showing">
+  <modal showing.bind="showing" large="true" small="true">
     <modal-header title="Name Goes Here" close.call="closeEventGoesHere()"></modal-header>
     <modal-body content-view="view-model-path-goes-here" content-model.bind="model-name-goes-here"></modal-body>
     <modal-footer>
@@ -44,6 +44,8 @@ This plugin is for the [Aurelia](http://www.aurelia.io/) platform. It sets up a 
   ```
 
 (Note that when You don't want to close button in modal-header, then use `close.bind="false"` instead of `close.call="closeEventGoesHere()"` in modal-header)
+
+(Also note that you can't have both the large attribute and the small attribute. If both are present the modal will get the default size)
 
 5. Update the bindings to be events in the view model that backs whereever you added the sample -
   ```javascript

--- a/src/modal.html
+++ b/src/modal.html
@@ -1,6 +1,6 @@
 <template>
   <div ref="modal" class="modal fade">
-    <div class="modal-dialog">
+    <div class.bind="modalClass">
       <div class="modal-content">
         <content select="modal-header"></content>
         <content select="modal-body"></content>

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,12 +1,24 @@
-import {inject, customElement, bindable} from 'aurelia-framework';
+import {inject, computedFrom, customElement, bindable} from 'aurelia-framework';
 import $ from 'jquery';
 
 @customElement('modal')
 @inject(Element)
 export class Modal {
   @bindable showing = false;
+  @bindable large = false;
+  @bindable small = false;
   constructor(element) {
     this.element = element;
+  }
+  @computedFrom('large', 'small')
+  get modalClass() {
+	  var className = 'modal-dialog';
+	  if(this.large && !this.small) {
+		  className += ' modal-lg';
+	  } else if(!this.small && this.large) {
+		  className += ' modal-sm';
+	  }
+	  return className;
   }
   attached(){
     $(this.modal).modal({show: false})


### PR DESCRIPTION
Sorry about all the sudden pull requests, but I wanted this functionality and as far as I understood we don't have support for custom templates for the modal-dialog class yet.

I am actually not sure if you should accept this pull request based on your comment in the issue this will resolve ( #10 ). I have added support for large and small modals by using `<modal large.bind="isLarge()" small.bind="isSmall()">...</modal>`.
